### PR TITLE
Ignore EOF error on stream recv.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -140,7 +140,7 @@ func driver(cfg *config) trace.Driver {
 				info.Call.FunctionID(),
 			)
 			return func(info trace.DriverConnStreamRecvMsgDoneInfo) {
-				finish(start, info.Error)
+				finish(start, skipEOF(info.Error))
 			}
 		},
 		OnConnStreamSendMsg: func(info trace.DriverConnStreamSendMsgStartInfo) func(trace.DriverConnStreamSendMsgDoneInfo) {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,13 @@
+package ydb
+
+import (
+	"errors"
+	"io"
+)
+
+func skipEOF(err error) error {
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	return err
+}

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 func skipEOF(err error) error {
-	if errors.Is(err, io.EOF) {
+	if err == nil || errors.Is(err, io.EOF) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

connError{node_id:50052,address:'hostname:2135'}: transport/Unknown (code = 2, source error = "EOF", address: "hostname:2135") at github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*grpcClientStream).RecvMsg(grpc_client_stream.go:147)
Issue Number: #19

## What is the new behavior?

EOF error is skipped

## Other information
